### PR TITLE
fix: read top-reviews

### DIFF
--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/Menu/Menu.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/Menu/Menu.java
@@ -110,7 +110,7 @@ public class Menu {
             }
         }
 
-        return null;
+        return menuDishes.get(0).getDish();
     }
 
 

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/Review/ReviewService.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/Review/ReviewService.java
@@ -160,7 +160,7 @@ public class ReviewService {
         List<Review> result = new ArrayList<>();
         for (Menu menu : restaurant.getMenuList()) {
             // 학생 식당만 넣어준다.(1학에서는 모든 DEPT가 STUDENT로 취급하자.)
-            if(deptFilter(dept, menu.getDept())) continue;
+            if(!deptFilter(dept, menu.getDept())) continue;
             Dish mainDish = menu.getMainDish();
 
             if(mainDish == null) continue;
@@ -183,13 +183,13 @@ public class ReviewService {
      */
     public boolean deptFilter(Dept standard, Dept target){
         if(standard.equals(Dept.STUDENT)){
-            if(target.equals(Dept.STAFF)) return true;
-            return false;
+            if(target.equals(Dept.STAFF)) return false;
+            return true;
         }
 
         // STUDENT가 아니라면 STAFF일 것이다.
         if(standard.equals(Dept.STAFF)){
-            if(target.equals(Dept.STAFF)) return false;
+            if(target.equals(Dept.STUDENT)) return false;
             return true;
         }
 

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/Review/ReviewService.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/Review/ReviewService.java
@@ -177,8 +177,8 @@ public class ReviewService {
     }
 
     /**
-     * standard의 dept가 STUDENT이면 target이 JAPANESE와 같은 1학의 카테고리들이거나 STUDENT일 때 true로 반환하고,
-     * STAFF이면 오직 STAFF만 반환하는 메서드
+     * standard의 dept가 STUDENT일때: target이 "1학 카테고리(ex: JAPANESE)" 또는 "STUDENT"일 때 true 반환
+     * standard의 dept가 STAFF일때  : target이 STAFF일 때 true 반환
      * @return
      */
     public boolean deptFilter(Dept standard, Dept target){
@@ -187,13 +187,11 @@ public class ReviewService {
             return true;
         }
 
-        // STUDENT가 아니라면 STAFF일 것이다.
         if(standard.equals(Dept.STAFF)){
             if(target.equals(Dept.STUDENT)) return false;
             return true;
         }
 
-        // 만약 STUDENT와 STAFF가 아닌 다른 DEPT가 stadard에 왔다면 잘못된 호출이다.
         throw new IllegalArgumentException("standard에는 STUDENT와 STAFF만 올 수 있습니다.");
     }
 


### PR DESCRIPTION
**코드 수정 제안**
deptFilter 코드 및 주석을 이해하는데 제가 야아악간 헤맸어서,
좀 더 가독성/이해하기 좋게 바꿔보았습니다.
어떤가요? @shxnzxxn 이부분 한번 검토 부탁드립니다!

**핵심 문제점:**
다음 Dish들 중 MainDish가 없어서 null을 반환하여, 최종적으로 리뷰를 불러오지 못하는 문제.
임시로 .get(0)으로 첫번째 항목을 가져오게해서 해결했으나, DishType에 MAIN이 없을 경우 (지정하지 못했을 경우?)를 고민해봐야 하겠다. 
일단 .get(0)하는 것에 대해서는 문제가 없다고 생각한다. 그 이유는...
1) 어차피 지정하지 않으면 MAIN-Dish는 존재하지 않기 때문에 임의 지정.
2) 어차피 올바르게 MAIN-Dish를 손수 지정해줘야 하는 구조이다. 만약 임의지정된 상태에서 리뷰를 작성하더라도 리뷰에 연결되는 것은 MENU이다. 결국 오늘Menu의 MAIN-Dish를 올바르게 재지정해준다면, 언젠가 다른날짜에서도 올바른 MAIN-Dish를 통하여 이전 리뷰들을 불러올 수 있다.

**요약: top-reivew 조회 로직에서 MAIN-Dish 기준으로 조회하는데, 1학 데이터 외에는 MAIN-Dish를 설정 안해서, 1학 데이터만 정상적으로 보였던 것이 문제였습니다.** 


