### PR TITLE
fix: review item like problem

### DIFF
--- a/frontend/src/pages/ReviewPage/ReviewList.js
+++ b/frontend/src/pages/ReviewPage/ReviewList.js
@@ -72,9 +72,12 @@ const ReviewList = ({
 	wholeReviewList,
 	setWholeReviewList,
 }) => {
-	const [review, setReview] = useState([]);
 	const [isChecked, setIsChecked] = useState(false);
 	const [sortOrder, setSortOrder] = useState("latest");
+
+	const toggleOnlyImageReviewVisiblity = () => {
+		setIsChecked(!isChecked);
+	};
 
 	const initialSetting = () => {
 		setIsChecked(false);
@@ -82,17 +85,17 @@ const ReviewList = ({
 	};
 
 	useEffect(() => {
-		nowReviewList &&
-			setReview(
-				[...nowReviewList].sort(
-					(a, b) => new Date(b.madeTime) - new Date(a.madeTime)
-				)
-			);
 		initialSetting();
-	}, [idx, nowReviewList]);
+		const beforeReviewList = [...wholeReviewList];
+		beforeReviewList[idx] = nowReviewList.sort(sortFunctions["latest"]);
+		setWholeReviewList(beforeReviewList);
+	}, [idx]);
 
-	const toggleOnlyImageReviewVisiblity = () => {
-		setIsChecked(!isChecked);
+	const sortFunctions = {
+		latest: (a, b) => new Date(b.madeTime) - new Date(a.madeTime),
+		earliest: (a, b) => new Date(a.madeTime) - new Date(b.madeTime),
+		highRate: (a, b) => b.rate - a.rate,
+		lowRate: (a, b) => a.rate - b.rate,
 	};
 
 	// 리뷰 정렬 구현하는 곳
@@ -100,18 +103,11 @@ const ReviewList = ({
 		const selectedSortOrder = event.target.value;
 		setSortOrder(selectedSortOrder);
 
-		if (selectedSortOrder === "latest") {
-			setReview(
-				[...review].sort((a, b) => new Date(b.madeTime) - new Date(a.madeTime))
-			);
-		} else if (selectedSortOrder === "earliest") {
-			setReview(
-				[...review].sort((a, b) => new Date(a.madeTime) - new Date(b.madeTime))
-			);
-		} else if (selectedSortOrder === "highRate") {
-			setReview([...review].sort((a, b) => b.rate - a.rate));
-		} else if (selectedSortOrder === "lowRate") {
-			setReview([...review].sort((a, b) => a.rate - b.rate));
+		if (selectedSortOrder && sortFunctions[selectedSortOrder]) {
+			const sortedReview = [...nowReviewList].sort(sortFunctions[selectedSortOrder]);
+			const afterReviewList = [...wholeReviewList];
+			afterReviewList[idx] = sortedReview;
+			setWholeReviewList(afterReviewList);
 		}
 	};
 
@@ -134,10 +130,10 @@ const ReviewList = ({
 					<option value="lowRate">별점 낮은순</option>
 					<option value="highRate">별점 높은순</option>
 				</SortingSelect>
-				{review.length === 0 ? (
+				{nowReviewList.length === 0 ? (
 					<NoReviewMessage>첫 리뷰의 주인공이 되어주세요!</NoReviewMessage>
 				) : (
-					review.map((nowReview, nowIndex) => {
+					nowReviewList.map((nowReview, nowIndex) => {
 						if (isChecked && nowReview.imgLink === "") {
 							return null;
 						}

--- a/frontend/src/pages/ReviewPage/ReviewListType2.js
+++ b/frontend/src/pages/ReviewPage/ReviewListType2.js
@@ -109,7 +109,6 @@ const ReviewListType2 = ({
 	wholeReviewList,
 	setWholeReviewList,
 }) => {
-	const [review, setReview] = useState([]);
 	const [isChecked, setIsChecked] = useState(false);
 	const [sortOrder, setSortOrder] = useState("latest");
 
@@ -129,22 +128,26 @@ const ReviewListType2 = ({
 	};
 
 	useEffect(() => {
-		setReview(
-			[...nowReviewList].sort(
-				(a, b) => new Date(b.madeTime) - new Date(a.madeTime)
-			)
-		);
-
 		const staffMenuData = nowMenu.filter((item) => item.dept === "STAFF");
 		setStaffMenu(staffMenuData);
 		const studentMenuData = nowMenu.filter((item) => item.dept !== "STAFF");
 		setStudentMenu(studentMenuData);
 
 		initialSetting();
-	}, [idx, nowReviewList, nowMenu]);
+		const beforeReviewList = [...wholeReviewList];
+		beforeReviewList[idx] = nowReviewList.sort(sortFunctions["latest"]);
+		setWholeReviewList(beforeReviewList);
+	}, [idx, nowMenu]);
 
 	const toggleOnlyImageReviewVisiblity = () => {
 		setIsChecked(!isChecked);
+	};
+
+	const sortFunctions = {
+		latest: (a, b) => new Date(b.madeTime) - new Date(a.madeTime),
+		earliest: (a, b) => new Date(a.madeTime) - new Date(b.madeTime),
+		highRate: (a, b) => b.rate - a.rate,
+		lowRate: (a, b) => a.rate - b.rate,
 	};
 
 	// 리뷰 정렬 구현하는 곳
@@ -152,18 +155,11 @@ const ReviewListType2 = ({
 		const selectedSortOrder = event.target.value;
 		setSortOrder(selectedSortOrder);
 
-		if (selectedSortOrder === "latest") {
-			setReview(
-				[...review].sort((a, b) => new Date(b.madeTime) - new Date(a.madeTime))
-			);
-		} else if (selectedSortOrder === "earliest") {
-			setReview(
-				[...review].sort((a, b) => new Date(a.madeTime) - new Date(b.madeTime))
-			);
-		} else if (selectedSortOrder === "highRate") {
-			setReview([...review].sort((a, b) => b.rate - a.rate));
-		} else if (selectedSortOrder === "lowRate") {
-			setReview([...review].sort((a, b) => a.rate - b.rate));
+		if (selectedSortOrder && sortFunctions[selectedSortOrder]) {
+			const sortedReview = [...nowReviewList].sort(sortFunctions[selectedSortOrder]);
+			const afterReviewList = [...wholeReviewList];
+			afterReviewList[idx] = sortedReview;
+			setWholeReviewList(afterReviewList);
 		}
 	};
 
@@ -243,10 +239,10 @@ const ReviewListType2 = ({
 				</SortingSelect>
 
 				{radioValue === "STUDENT" ? (
-					review.filter((item) => item.dept === "STUDENT").length === 0 ? (
+					nowReviewList.filter((item) => item.dept === "STUDENT").length === 0 ? (
 						<NoReviewMessage>첫 리뷰의 주인공이 되어주세요!</NoReviewMessage>
 					) : (
-						review.map((nowReview, nowIndex) => {
+						nowReviewList.map((nowReview, nowIndex) => {
 							if (isChecked && nowReview.imgLink === "") {
 								return null;
 							}
@@ -260,10 +256,10 @@ const ReviewListType2 = ({
 							) : null;
 						})
 					)
-				) : review.filter((item) => item.dept === "STAFF").length === 0 ? (
+				) : nowReviewList.filter((item) => item.dept === "STAFF").length === 0 ? (
 					<NoReviewMessage>첫 리뷰의 주인공이 되어주세요!</NoReviewMessage>
 				) : (
-					review.map((nowReview, nowIndex) => {
+					nowReviewList.map((nowReview, nowIndex) => {
 						if (isChecked && nowReview.imgLink === "") {
 							return null;
 						}


### PR DESCRIPTION
## 문제사항
- 리뷰 페이지에서 정렬하는 경우, 공감이 제대로 표시되지 않는 문제
### 내용
- 리뷰 삭제와 같은 로직으로 (로그인한 유저의 공감 상황, 공감 수 처리)
  - 전체 탭에서 공감하는 경우, 해당 식당 탭에도 적용될 수 있도록
  - 식당 탭에서 공감하는 경우, 전체 탭에도 적용될 수 있도록

### 개발 서버에서 테스트 필요한 부분
_공감 클릭 후_
- dept 바꿔보기
- 메인 페이지 갔다가, 다시 리뷰 페이지 돌아오기
- 정렬 4가지 기능 모두 확인해보기
- 사진 리뷰만 보기 확인해보기
- N학 식당에서 공감 후 전체 탭에서 반영되는지 확인
- 전체 탭에서 공감 후 해당 식당 탭에서 반영되는지 확인