### PR TITLE
fix: validate each token param

### DIFF
--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/AOP/InvalidTokenException.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/AOP/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.SeeAndYouGo.SeeAndYouGo.AOP;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/AOP/TokenValidationAspect.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/AOP/TokenValidationAspect.java
@@ -1,0 +1,44 @@
+package com.SeeAndYouGo.SeeAndYouGo.AOP;
+
+import com.SeeAndYouGo.SeeAndYouGo.OAuth.jwt.TokenProvider;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class TokenValidationAspect {
+    private final TokenProvider provider;
+    private static final String TOKEN_ID_NAME = "tokenId";
+
+    @Autowired
+    public TokenValidationAspect(TokenProvider provider) {
+        this.provider = provider;
+    }
+
+    @Before("@annotation(ValidateToken)")
+    public void validateToken(JoinPoint joinPoint) throws InvalidTokenException {
+
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String[] paramNames = signature.getParameterNames();
+        Object[] args = joinPoint.getArgs();
+
+        String tokenId = null;
+        for (int i = 0; i < args.length; i++) {
+            if (paramNames[i].equals(TOKEN_ID_NAME)) {
+                tokenId = (String) args[i];
+                break;
+            }
+        }
+
+        if (tokenId == null || tokenId.length() == 0) {
+            throw new InvalidTokenException("Invalid Token");
+        }
+        if (!provider.validateToken(tokenId)) {
+            throw new InvalidTokenException("Invalid Token");
+        }
+    }
+}

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/AOP/ValidateToken.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/AOP/ValidateToken.java
@@ -1,0 +1,11 @@
+package com.SeeAndYouGo.SeeAndYouGo.AOP;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidateToken {
+}

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/Keyword/KeywordController.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/Keyword/KeywordController.java
@@ -1,5 +1,6 @@
 package com.SeeAndYouGo.SeeAndYouGo.Keyword;
 
+import com.SeeAndYouGo.SeeAndYouGo.AOP.ValidateToken;
 import com.SeeAndYouGo.SeeAndYouGo.Keyword.dto.KeywordAddResponseDto;
 import com.SeeAndYouGo.SeeAndYouGo.Keyword.dto.KeywordRequestDto;
 import com.SeeAndYouGo.SeeAndYouGo.Keyword.dto.KeywordResponseDto;
@@ -18,8 +19,9 @@ public class KeywordController {
     private final TokenProvider tokenProvider;
 
     @GetMapping("/{user_id}")
-    public KeywordResponseDto getKeywordsByUser(@PathVariable String user_id) {
-        String email = tokenProvider.decodeToEmail(user_id);
+    @ValidateToken
+    public KeywordResponseDto getKeywordsByUser(@PathVariable("user_id") String tokenId) {
+        String email = tokenProvider.decodeToEmail(tokenId);
         List<Keyword> keywords = keywordService.getKeywords(email);
         return KeywordResponseDto.toDTO(keywords);
     }

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/Menu/MenuController.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/Menu/MenuController.java
@@ -1,7 +1,6 @@
 package com.SeeAndYouGo.SeeAndYouGo.Menu;
 
 import com.SeeAndYouGo.SeeAndYouGo.Dish.Dish;
-import com.SeeAndYouGo.SeeAndYouGo.Keyword.Keyword;
 import com.SeeAndYouGo.SeeAndYouGo.Keyword.UserKeyword;
 import com.SeeAndYouGo.SeeAndYouGo.Keyword.UserKeywordRepository;
 import com.SeeAndYouGo.SeeAndYouGo.OAuth.jwt.TokenProvider;
@@ -30,13 +29,14 @@ public class MenuController {
     private final TokenProvider tokenProvider;
 
     @GetMapping(value = {"/daily-menu/{restaurant}/{user_id}", "/daily-menu/{restaurant}"})
-    public ResponseEntity<List<MenuResponseByUserDto>> restaurantMenuDayByUser(@PathVariable("restaurant") String place, @PathVariable(required = false) String user_id) {
+    public ResponseEntity<List<MenuResponseByUserDto>> restaurantMenuDayByUser(@PathVariable("restaurant") String place,
+                                                                               @PathVariable(value = "user_id", required = false) String tokenId) {
         String date = getTodayDate();
         List<Menu> oneDayRestaurantMenu = menuService.getOneDayRestaurantMenu(place, date);
 
         List<String> keyStrings = new ArrayList<>();
-        if (user_id != null) {
-            String email = tokenProvider.decodeToEmail(user_id);
+        if (tokenId != null) {
+            String email = tokenProvider.decodeToEmail(tokenId);
             User user = userRepository.findByEmail(email).get(0);
             List<UserKeyword> keywords = userKeywordRepository.findByUser(user);
             keyStrings = keywords.stream().map(x -> x.getKeyword().getName()).collect(Collectors.toList());

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/OAuth/jwt/JwtFilter.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/OAuth/jwt/JwtFilter.java
@@ -38,7 +38,7 @@ public class JwtFilter extends OncePerRequestFilter {
             Authentication authentication = tokenProvider.getAuthentication(jwt);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
-        // SecurityContext에서 허가된 URI 외에 모든 request요청은 필터를 거치고 토큰 정보가 유효하지 않으면 정상적으로 수행되지 않음
+        // SecurityContext에서 허가된 URI 외에 모든 request요청은 필터를 거침
         filterChain.doFilter(request, response);
     }
 }

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/like/LikeController.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/like/LikeController.java
@@ -1,8 +1,8 @@
 package com.SeeAndYouGo.SeeAndYouGo.like;
 
+import com.SeeAndYouGo.SeeAndYouGo.AOP.ValidateToken;
 import com.SeeAndYouGo.SeeAndYouGo.like.dto.LikeResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 public class LikeController {
     private final LikeService likeService;
     @PostMapping("/review/like/{review_id}/{token_id}")
+    @ValidateToken
     public LikeResponseDto postLikeCount(@PathVariable("review_id") Long reviewId,
                                          @PathVariable("token_id") String tokenId){
         // 만약 해당 유저가 공감을 누른 상태였다면, 공감 삭제

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/user/UserController.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/user/UserController.java
@@ -1,5 +1,6 @@
 package com.SeeAndYouGo.SeeAndYouGo.user;
 
+import com.SeeAndYouGo.SeeAndYouGo.AOP.ValidateToken;
 import com.SeeAndYouGo.SeeAndYouGo.OAuth.jwt.TokenProvider;
 import com.SeeAndYouGo.SeeAndYouGo.user.dto.NicknameCheckResponseDto;
 import com.SeeAndYouGo.SeeAndYouGo.user.dto.UserNicknameRequest;
@@ -36,14 +37,14 @@ public class UserController {
     }
 
     @GetMapping("/nickname/{token}")
-    public ResponseEntity<UserResponseDto> getNickname(@PathVariable String token){
-        String email = tokenProvider.decodeToEmail(token);
+    @ValidateToken
+    public ResponseEntity<UserResponseDto> getNickname(@PathVariable(value = "token") String tokenId){
+        String email = tokenProvider.decodeToEmail(tokenId);
         String nickname = userService.getNicknameByEmail(email);
 
         UserResponseDto userResponseDto = UserResponseDto.builder()
                                             .nickname(nickname)
-                                    .build();
-
+                                            .build();
         return ResponseEntity.ok(userResponseDto);
     }
 }


### PR DESCRIPTION
tokenId를 AOP로 검증하도록 개선했습니다.

요약: tokenId를 넘겨받고 있는 메서드에서, tokenId가 유효한지 검증하는 위치를 통일했습니다.

상세: @ValidateToken 어노테이션이 붙은 메서드가 실행되기 전에, tokenId라는 이름을 가진 파라미터값이 유효하지 않은 토큰일 경우, TokenValidationAspect에서 InvalidTokenException를 일으키도록 했습니다. 일관된 token 검증을 할 수 있을 것이라고 생각합니다. 

https://splendidlolli.tistory.com/725


추가: tokenId 부분 정리하면서, top-review 조회 로직에 tokenId값이 넘어가는 GetMapping이 존재하는 것을 발견했습니다. 그런데 top-review 조회에서는 tokenId가 필요없어서, 해당 부분 제거해주었습니다! 그런데 혹시나 top-review 조회시 tokenId를 확인하는 건에 대하여.. 제가 간과한 부분이 있는지 검토 부탁드립니다. (노션 API 명세에는 없는 걸 확인했습니다)

Close #174