### PR TITLE
fix: only use select box in restaurant 1

### DIFF
--- a/frontend/src/pages/MainPage/TopReview.js
+++ b/frontend/src/pages/MainPage/TopReview.js
@@ -73,15 +73,15 @@ const NoReviewMessage = styled.p`
 const SelectOptionArray = [
 	[],
 	["전체", "라면&간식", "스낵", "한식", "일식", "중식", "양식"],
-	["전체", "조식", "중식-학생", "중식-교직원"],
-	["전체", "중식-학생", "중식-교직원", "석식"],
+	// ["전체", "조식", "중식-학생", "중식-교직원"],
+	// ["전체", "중식-학생", "중식-교직원", "석식"],
 ];
 
 const OptionValueArray = [
 	[],
 	["total", "noodle", "snack", "korean", "japanese", "chinese", "western"],
-	["total", "morning", "lunch-student", "lunch-staff", "dinner"],
-	["total", "lunch-student", "lunch-staff", "dinner"],
+	// ["total", "breakfast", "lunch-student", "lunch-staff", "dinner"],
+	// ["total", "lunch-student", "lunch-staff", "dinner"],
 ];
 
 const TopReview = ({
@@ -106,18 +106,18 @@ const TopReview = ({
 		switch (typeValue) {
 			case "total":
 				return beforeData;
-			case "morning":
-				return beforeData.filter((data) => data.menuType === "MORNING");
-			case "lunch-student":
-				return beforeData.filter(
-					(data) => data.menuType === "LUNCH" && data.dept === "STUDENT"
-				);
-			case "lunch-staff":
-				return beforeData.filter(
-					(data) => data.menuType === "LUNCH" && data.dept !== "STUDENT"
-				);
-			case "dinner":
-				return beforeData.filter((data) => data.menuType === "DINNER");
+			// case "breakfast":
+			// 	return beforeData.filter((data) => data.menuType === "BREAKFAST");
+			// case "lunch-student":
+			// 	return beforeData.filter(
+			// 		(data) => data.menuType === "LUNCH" && data.dept === "STUDENT"
+			// 	);
+			// case "lunch-staff":
+			// 	return beforeData.filter(
+			// 		(data) => data.menuType === "LUNCH" && data.dept !== "STUDENT"
+			// 	);
+			// case "dinner":
+			// 	return beforeData.filter((data) => data.menuType === "DINNER");
 
 			case "noodle":
 				return beforeData.filter((data) => data.dept === "NOODLE");
@@ -175,7 +175,8 @@ const TopReview = ({
 				사진 리뷰만
 			</label>
 
-			{idx === 4 || idx === 5 ? null : (
+			{/* {idx === 4 || idx === 5 ? null : ( */}
+			{idx === 1 ?  
 				<TopReviewSelect value={selectedReviewType} onChange={handleSelectType}>
 					{(SelectOptionArray[idx] || []).map((item, index) => (
 					<option key={index} value={OptionValueArray[idx][index]}>
@@ -183,7 +184,8 @@ const TopReview = ({
 					</option>
 					))}
 				</TopReviewSelect>
-			)}
+				: null
+			}
 
 			{reviewData.length === 0 ? (
 			<NoReviewMessage>첫 리뷰의 주인공이 되어주세요!</NoReviewMessage>


### PR DESCRIPTION
기존에는 menuType과 dept 구분을 통해 top review를 분류할 수 있도록 했으나,
현재 review 구조상으론 기존의 동작이 애매하다고 생각해
mainDishList로 리뷰를 분류할 수 있도록 만들자는 의견이 나왔으나,

프론트 측에서 봤을 때, 데이터 관리가 원하는 방향대로 구현하기 어렵다고 판단되어
일단 1학생회관만 select box가 있도록 하고,
나머지 식당들은 전체 리뷰만 보이고 select box가 안 보이게 한다.

추후에 수정 및 보완이 필요한 부분이다.