### PR TITLE
refactor: replace magic strings with constants

### DIFF
--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/global/MenuConstants.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/global/MenuConstants.java
@@ -1,0 +1,26 @@
+package com.SeeAndYouGo.SeeAndYouGo.global;
+
+/**
+ * 메뉴 관련 상수를 정의하는 클래스.
+ */
+public final class MenuConstants {
+
+    private MenuConstants() {
+        // 유틸리티 클래스이므로 인스턴스화 방지
+    }
+
+    /**
+     * 메뉴 정보가 없을 때 사용하는 기본 메뉴명
+     */
+    public static final String DEFAULT_DISH_NAME = "메뉴 정보 없음";
+
+    /**
+     * 운영 중단 상태를 나타내는 문자열
+     */
+    public static final String OPERATION_SUSPENDED = "운영중단";
+
+    /**
+     * 운영 안함 상태를 나타내는 문자열
+     */
+    public static final String NOT_OPERATING = "운영안함";
+}

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/Menu.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/Menu.java
@@ -2,6 +2,7 @@ package com.SeeAndYouGo.SeeAndYouGo.menu;
 
 import com.SeeAndYouGo.SeeAndYouGo.dish.Dish;
 import com.SeeAndYouGo.SeeAndYouGo.dish.DishType;
+import com.SeeAndYouGo.SeeAndYouGo.global.MenuConstants;
 import com.SeeAndYouGo.SeeAndYouGo.menu.dto.MenuVO;
 import com.SeeAndYouGo.SeeAndYouGo.menuDish.MenuDish;
 import com.SeeAndYouGo.SeeAndYouGo.restaurant.Restaurant;
@@ -93,7 +94,9 @@ public class Menu {
     private static boolean checkIsOpen(Dish dish) {
         String name = dish.getName();
 
-        return !name.equals("메뉴 정보 없음") && !name.contains("운영중단") && !name.contains("운영안함");
+        return !name.equals(MenuConstants.DEFAULT_DISH_NAME)
+                && !name.contains(MenuConstants.OPERATION_SUSPENDED)
+                && !name.contains(MenuConstants.NOT_OPERATING);
     }
 
     /**

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/MenuService.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/MenuService.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import static com.SeeAndYouGo.SeeAndYouGo.IterService.getNearestMonday;
 import static com.SeeAndYouGo.SeeAndYouGo.IterService.getSundayOfWeek;
 import static com.SeeAndYouGo.SeeAndYouGo.global.DateTimeFormatters.DATE;
+import static com.SeeAndYouGo.SeeAndYouGo.global.MenuConstants.DEFAULT_DISH_NAME;
 
 @Service
 @Transactional(readOnly = true)
@@ -39,8 +40,6 @@ public class MenuService {
     // 로컬에서 운영서버로 데이터를 넘겨주기 위함.
     private final MenuProviderFactory menuProviderFactory;
     private final NewDishCacheService newDishCacheService;
-
-    public static final String DEFAULT_DISH_NAME = "메뉴 정보 없음";
 
     @Value("${API.DISH_KEY}")
     private String DISH_KEY;
@@ -244,7 +243,7 @@ public class MenuService {
             Menu menu = menus.get(i);
 
             // 만약 메뉴정보가 없다면 올리지 않는 방향으로!
-            if(menu.getDishList().get(0).getName().equals("메뉴 정보 없음"))
+            if(menu.getDishList().get(0).getName().equals(DEFAULT_DISH_NAME))
                 continue;
 
             sb.append(menu.getDept().getKoreanDept()+"식당 : ");

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/menuProvider/ApiMenuProvider.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/menuProvider/ApiMenuProvider.java
@@ -29,6 +29,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.SeeAndYouGo.SeeAndYouGo.global.DateTimeFormatters.DATE_COMPACT;
+import static com.SeeAndYouGo.SeeAndYouGo.global.MenuConstants.DEFAULT_DISH_NAME;
 
 @Component
 @RequiredArgsConstructor
@@ -269,7 +270,7 @@ public class ApiMenuProvider implements MenuProvider{
             }
         }
 
-        // Fill missing menus with default "메뉴 정보 없음"
+        // Fill missing menus with default dish
         fillMissingMenus(restaurant, date, dailyMenu);
 
         // menuMap에서 해당 날짜의 메뉴를 찾아 교체
@@ -308,7 +309,7 @@ public class ApiMenuProvider implements MenuProvider{
 
         if (!menuExists) {
             MenuVO defaultMenu = new MenuVO(0, date.toString(), dept, restaurant, menuType);
-            defaultMenu.addDishVO(new DishVO("메뉴 정보 없음", DishType.SIDE));
+            defaultMenu.addDishVO(new DishVO(DEFAULT_DISH_NAME, DishType.SIDE));
             dailyMenu.add(defaultMenu);
         }
     }

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/menuProvider/CrawlingMenuProvider.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/menuProvider/CrawlingMenuProvider.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.SeeAndYouGo.SeeAndYouGo.global.DateTimeFormatters.DATE;
+import static com.SeeAndYouGo.SeeAndYouGo.global.MenuConstants.DEFAULT_DISH_NAME;
 
 @Component
 @RequiredArgsConstructor
@@ -199,7 +200,7 @@ public class CrawlingMenuProvider implements MenuProvider{
 
     private void addDefaultMenu(List<MenuVO> menus, LocalDate date, Dept dept, Restaurant restaurant, MenuType menuType) {
         MenuVO defaultMenu = new MenuVO(0, date.toString(), dept, restaurant, menuType);
-        DishVO defaultDish = new DishVO("메뉴 정보 없음", DishType.SIDE);
+        DishVO defaultDish = new DishVO(DEFAULT_DISH_NAME, DishType.SIDE);
 
         defaultMenu.addDishVO(defaultDish);
         menus.add(defaultMenu);


### PR DESCRIPTION
## Summary
- `MenuConstants` 클래스 생성: `DEFAULT_DISH_NAME`, `OPERATION_SUSPENDED`, `NOT_OPERATING` 상수 정의
- `Menu.java`: 매직 스트링을 `MenuConstants` 상수로 교체
- `MenuService.java`: static import를 사용하여 `DEFAULT_DISH_NAME` 상수 참조
- `ApiMenuProvider.java`: `DEFAULT_DISH_NAME` 상수 사용
- `CrawlingMenuProvider.java`: `DEFAULT_DISH_NAME` 상수 사용

## Test plan
- [x] 빌드 성공 확인 (`./gradlew clean build -x test`)
- [ ] 메뉴 조회 기능 정상 동작 확인

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)