### PR TITLE
refactor: improve logging consistency

### DIFF
--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/MenuService.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/MenuService.java
@@ -231,7 +231,7 @@ public class MenuService {
                 .content(message)
                 .build();
 
-        logger.info("[API_JJONGAL] 데이터: " + dto.toString());
+        logger.info("[API_JJONGAL] 데이터: {}", dto);
 
         return dto;
     }

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/menuProvider/CrawlingMenuProvider.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/menuProvider/CrawlingMenuProvider.java
@@ -290,7 +290,7 @@ public class CrawlingMenuProvider implements MenuProvider{
         }
 
         if (menuMap.containsKey(newTitle)) {
-            System.out.println("중복된 메뉴 코너가 발생했습니다: " + newTitle);
+            logger.warn("중복된 메뉴 코너가 발생했습니다: {}", newTitle);
             throw new IllegalStateException("Duplicate menu corner found: " + newTitle);
         }
         menuMap.put(newTitle, new ArrayList<>(menuList));


### PR DESCRIPTION
## Summary
- `MenuService.java`: 문자열 연결 대신 SLF4J placeholder 사용
- `CrawlingMenuProvider.java`: `System.out.println`을 `logger.warn`으로 교체

## Before
```java
// MenuService.java
logger.info("[API_JJONGAL] 데이터: " + dto.toString());

// CrawlingMenuProvider.java
System.out.println("중복된 메뉴 코너가 발생했습니다: " + newTitle);
```

## After
```java
// MenuService.java
logger.info("[API_JJONGAL] 데이터: {}", dto);

// CrawlingMenuProvider.java
logger.warn("중복된 메뉴 코너가 발생했습니다: {}", newTitle);
```

## Test plan
- [x] 빌드 성공 확인

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)