### PR TITLE
refactor: extract duplicated MenuType parsing logic

### DIFF
--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/MenuType.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/MenuType.java
@@ -11,6 +11,15 @@ public enum MenuType {
         else return MenuType.DINNER;
     }
 
+    public static MenuType fromKorean(String korean) {
+        if ("아침".equals(korean)) {
+            return BREAKFAST;
+        } else if ("점심".equals(korean)) {
+            return LUNCH;
+        }
+        return DINNER;
+    }
+
     /**
      * timeStr에 맞는 MenuType을 return.
      * @param timeStr 형식은 08:15나 08:15:22 와 같은 형태여야한다.

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/menuProvider/CrawlingMenuProvider.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/menu/menuProvider/CrawlingMenuProvider.java
@@ -70,14 +70,7 @@ public class CrawlingMenuProvider implements MenuProvider{
             Elements mealTds = dayDocument.select(".diet_table td");
             for (Element mealTd : mealTds) {
                 String mealTypeStr = mealTd.attr("data-cell-header");
-                MenuType menuType;
-                if (mealTypeStr.equals("아침")) {
-                    menuType = MenuType.BREAKFAST;
-                } else if (mealTypeStr.equals("점심")) {
-                    menuType = MenuType.LUNCH;
-                } else {
-                    menuType = MenuType.DINNER;
-                }
+                MenuType menuType = MenuType.fromKorean(mealTypeStr);
 
                 String menuContent = mealTd.toString();
                 if (!menuContent.isEmpty()) {
@@ -134,14 +127,7 @@ public class CrawlingMenuProvider implements MenuProvider{
             Elements mealTds = dayDocument.select(".diet_table td");
             for (Element mealTd : mealTds) {
                 String mealTypeStr = mealTd.attr("data-cell-header");
-                MenuType menuType;
-                if (mealTypeStr.equals("아침")) {
-                    menuType = MenuType.BREAKFAST;
-                } else if (mealTypeStr.equals("점심")) {
-                    menuType = MenuType.LUNCH;
-                } else {
-                    menuType = MenuType.DINNER;
-                }
+                MenuType menuType = MenuType.fromKorean(mealTypeStr);
 
                 String menuContent = mealTd.toString();
                 if (!menuContent.isEmpty()) {


### PR DESCRIPTION
## Summary
- `MenuType.fromKorean()` 메서드 추가 (아침/점심/저녁 → BREAKFAST/LUNCH/DINNER)
- CrawlingMenuProvider의 중복된 if-else 체인을 새 메서드로 교체

## Before
```java
// 두 곳에서 동일한 코드 반복
if (mealTypeStr.equals("아침")) {
    menuType = MenuType.BREAKFAST;
} else if (mealTypeStr.equals("점심")) {
    menuType = MenuType.LUNCH;
} else {
    menuType = MenuType.DINNER;
}
```

## After
```java
MenuType menuType = MenuType.fromKorean(mealTypeStr);
```

## 수정 파일
- `MenuType.java`: fromKorean() 메서드 추가
- `CrawlingMenuProvider.java`: 중복 코드 제거

## Test plan
- [x] 빌드 성공 확인
- [ ] 크롤링 기능 테스트

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)