### PR TITLE
feat: 혼잡도 예측 API 스펙 변경 대응 (nullable prediction/current_count)

### DIFF
--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/connection/ConnectionController.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/connection/ConnectionController.java
@@ -42,6 +42,10 @@ public class ConnectionController {
     /**
      * 외부 예측 서버에서 받아온 혼잡도 예측 결과를 그대로 릴레이한다.
      * 호출 전 예측 서버 헬스체크를 수행한다.
+     *
+     * results는 horizon마다 개별 판정이라 일부만 status="unavailable", prediction=null일 수 있다.
+     * 클라이언트는 status가 "ok"가 아니면 예측값을 표시하지 말아야 하며 0으로 폴백하면 안 된다.
+     *
      * @param restaurant 식당 식별자 (예: restaurant1, 제1학생회관)
      * @param observedAt 관측 시각 (yyyy-MM-dd HH:mm:ss)
      */

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/connection/PredictionService.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/connection/PredictionService.java
@@ -1,6 +1,9 @@
 package com.SeeAndYouGo.SeeAndYouGo.connection;
 
 import com.SeeAndYouGo.SeeAndYouGo.connection.dto.PredictionResponseDto;
+import com.SeeAndYouGo.SeeAndYouGo.connection.dto.PredictionResultDto;
+import com.SeeAndYouGo.SeeAndYouGo.connection.dto.PredictionServerRequest;
+import com.SeeAndYouGo.SeeAndYouGo.connection.dto.PredictionServerResponse;
 import com.SeeAndYouGo.SeeAndYouGo.restaurant.Restaurant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,18 +15,25 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import javax.annotation.PostConstruct;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -33,9 +43,16 @@ public class PredictionService {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private static final int OBSERVATION_WINDOW_MINUTES = 5;
 
+    /** 예측 서버는 오프셋이 포함된 ISO-8601을 권장한다. 관측 시각은 모두 KST 기준이다. */
+    private static final ZoneOffset KST = ZoneOffset.ofHours(9);
+
+    /** 예측 서버가 허용하는 horizon 값. 그 외를 보내면 400이 떨어진다. */
+    private static final Set<Integer> SUPPORTED_HORIZONS =
+            Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(10, 20, 30, 60)));
+
     private static final String STATUS_OK = "OK";
     private static final String STATUS_INVALID_REQUEST = "INVALID_REQUEST";
-    private static final String STATUS_NO_OBSERVATION = "NO_OBSERVATION";
+    private static final String STATUS_UNSUPPORTED_RESTAURANT = "UNSUPPORTED_RESTAURANT";
     private static final String STATUS_PREDICTION_SERVER_DOWN = "PREDICTION_SERVER_DOWN";
     private static final String STATUS_PREDICTION_FAILED = "PREDICTION_FAILED";
 
@@ -54,6 +71,23 @@ public class PredictionService {
     private List<Integer> horizons;
 
     private final RestTemplate restTemplate = new RestTemplate();
+
+    /**
+     * 예측 서버는 10/20/30/60 외의 horizon에 400을, 빈 배열에 422를 반환한다.
+     * 설정이 잘못돼도 예측 기능만 조용히 죽지 않도록 부팅 시점에 걸러내고 로그를 남긴다.
+     */
+    @PostConstruct
+    void sanitizeHorizons() {
+        List<Integer> configured = horizons == null ? Collections.emptyList() : horizons;
+        List<Integer> valid = configured.stream()
+                .filter(SUPPORTED_HORIZONS::contains)
+                .collect(Collectors.toList());
+
+        if (valid.size() != configured.size()) {
+            log.error("지원하지 않는 horizon 설정을 제외합니다. 허용값={}, 설정값={}", SUPPORTED_HORIZONS, configured);
+        }
+        this.horizons = valid.isEmpty() ? new ArrayList<>(SUPPORTED_HORIZONS) : valid;
+    }
 
     public PredictionResponseDto predict(String restaurantParam, String observedAt) {
         // 1. 식당 검증
@@ -77,51 +111,45 @@ public class PredictionService {
                     restaurant.name(), observedAt);
         }
 
-        // 3. DB에서 ±5분 윈도우 내 가장 가까운 관측값 찾기
-        Optional<Connection> matched = findClosestObservation(restaurant, requestedTime);
-        if (!matched.isPresent()) {
-            return PredictionResponseDto.builder()
-                    .status(STATUS_NO_OBSERVATION)
-                    .message("해당 시간대(±" + OBSERVATION_WINDOW_MINUTES + "분) 관측 데이터가 없습니다.")
-                    .restaurantName(restaurant.name())
-                    .requestedAt(observedAt)
-                    .build();
-        }
+        // 3. DB에서 ±5분 윈도우 내 가장 가까운 관측값 찾기.
+        //    없으면 current_count를 null로 보내 베이스라인 기반 예측을 받는다. 0으로 보내면 안 된다.
+        Connection observed = findClosestObservation(restaurant, requestedTime).orElse(null);
+        LocalDateTime observationTime = observed == null ? requestedTime : parseTime(observed.getTime(), requestedTime);
+        Double currentCount = resolveCurrentCount(observed);
 
-        Connection observed = matched.get();
+        if (currentCount == null) {
+            log.info("관측 혼잡도 없이 예측 요청합니다(current_count=null). restaurant={}, observed_at={}",
+                    restaurant, observedAt);
+        }
 
         // 4. 예측 서버 헬스체크
         if (!isPredictionServerHealthy()) {
-            return PredictionResponseDto.builder()
-                    .status(STATUS_PREDICTION_SERVER_DOWN)
+            return baseResponse(STATUS_PREDICTION_SERVER_DOWN, restaurant, observedAt, observed)
                     .message("예측 서버가 응답하지 않습니다.")
-                    .restaurantName(restaurant.name())
-                    .requestedAt(observedAt)
-                    .observedAt(observed.getTime())
-                    .observedValue(observed.getConnected())
                     .build();
         }
 
         // 5. 외부 예측 서버 호출 후 응답 릴레이
         try {
-            Map<String, Object> predictions = callPredictionServer(restaurant, observed);
-            return PredictionResponseDto.builder()
-                    .status(STATUS_OK)
-                    .restaurantName(restaurant.name())
-                    .requestedAt(observedAt)
-                    .observedAt(observed.getTime())
-                    .observedValue(observed.getConnected())
-                    .predictions(predictions)
+            PredictionServerResponse prediction = callPredictionServer(restaurant, observationTime, currentCount);
+            return toResponse(restaurant, observedAt, observed, prediction);
+        } catch (HttpClientErrorException.NotFound e) {
+            // 404는 이제 "예측 서버가 모르는 식당"인 경우에만 발생한다.
+            log.warn("예측 서버가 모르는 식당입니다: restaurant={}", restaurant);
+            return baseResponse(STATUS_UNSUPPORTED_RESTAURANT, restaurant, observedAt, observed)
+                    .message("예측을 지원하지 않는 식당입니다.")
+                    .build();
+        } catch (HttpClientErrorException e) {
+            // 400: 지원하지 않는 horizon 값, 422: 요청 형식 오류. 둘 다 우리 쪽 요청 문제다.
+            log.error("예측 서버 요청이 거부되었습니다: restaurant={}, observed_at={}, status={}, body={}",
+                    restaurant, observedAt, e.getStatusCode(), e.getResponseBodyAsString());
+            return baseResponse(STATUS_PREDICTION_FAILED, restaurant, observedAt, observed)
+                    .message("예측 서버가 요청을 거부했습니다: " + e.getStatusCode())
                     .build();
         } catch (RestClientException e) {
             log.error("예측 서버 호출 실패: restaurant={}, observed_at={}", restaurant, observedAt, e);
-            return PredictionResponseDto.builder()
-                    .status(STATUS_PREDICTION_FAILED)
+            return baseResponse(STATUS_PREDICTION_FAILED, restaurant, observedAt, observed)
                     .message("예측 서버 호출 실패: " + e.getMessage())
-                    .restaurantName(restaurant.name())
-                    .requestedAt(observedAt)
-                    .observedAt(observed.getTime())
-                    .observedValue(observed.getConnected())
                     .build();
         }
     }
@@ -133,12 +161,30 @@ public class PredictionService {
                 log.warn("예측 캐시 워밍업 스킵 - 예측 서버 다운: restaurant={}", restaurant);
                 return;
             }
-            callPredictionServer(restaurant, observed);
+            LocalDateTime observationTime = parseTime(observed.getTime(), null);
+            if (observationTime == null) {
+                log.warn("예측 캐시 워밍업 스킵 - 관측 시각 파싱 실패: restaurant={}, time={}",
+                        restaurant, observed.getTime());
+                return;
+            }
+            callPredictionServer(restaurant, observationTime, resolveCurrentCount(observed));
             log.info("예측 캐시 워밍업 성공: restaurant={}, observed_at={}", restaurant, observed.getTime());
         } catch (Exception e) {
             log.warn("예측 캐시 워밍업 실패: restaurant={}, observed_at={}, error={}",
                     restaurant, observed.getTime(), e.getMessage());
         }
+    }
+
+    /**
+     * 현재 혼잡도를 모르면 null을 반환한다.
+     * 0을 보내면 예측 서버가 "사람이 정말 0명"으로 해석해 예측값이 40%가량 낮아진다.
+     * 비운영시간 센티널(-1)도 관측값이 아니므로 null로 취급한다.
+     */
+    private Double resolveCurrentCount(Connection observed) {
+        if (observed == null || observed.getConnected() == null || observed.getConnected() < 0) {
+            return null;
+        }
+        return observed.getConnected().doubleValue();
     }
 
     private Optional<Connection> findClosestObservation(Restaurant restaurant, LocalDateTime requestedTime) {
@@ -165,29 +211,97 @@ public class PredictionService {
         }
     }
 
-    private Map<String, Object> callPredictionServer(Restaurant restaurant, Connection observed) {
-        Map<String, Object> requestBody = new HashMap<>();
-        requestBody.put("restaurant", restaurant.name());
-        requestBody.put("observed_at", observed.getTime());
-        requestBody.put("current_count", observed.getConnected());
-        requestBody.put("horizons", horizons);
-        requestBody.put("debug", false);
+    private PredictionServerResponse callPredictionServer(Restaurant restaurant,
+                                                          LocalDateTime observationTime,
+                                                          Double currentCount) {
+        PredictionServerRequest requestBody = PredictionServerRequest.builder()
+                .restaurant(restaurant.name())
+                .observedAt(observationTime.atOffset(KST).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+                .currentCount(currentCount)
+                .horizons(horizons)
+                .debug(false)
+                .build();
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+        HttpEntity<PredictionServerRequest> entity = new HttpEntity<>(requestBody, headers);
 
-        @SuppressWarnings("rawtypes")
-        ResponseEntity<Map> response = restTemplate.exchange(
+        ResponseEntity<PredictionServerResponse> response = restTemplate.exchange(
                 baseUrl + predictEndpoint,
                 HttpMethod.POST,
                 entity,
-                Map.class
+                PredictionServerResponse.class
         );
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> body = response.getBody();
-        return body == null ? new HashMap<>() : body;
+        PredictionServerResponse body = response.getBody();
+        if (body == null) {
+            throw new RestClientException("예측 서버 응답 바디가 비어 있습니다.");
+        }
+
+        logDataQuality(restaurant, body);
+        return body;
+    }
+
+    /**
+     * recent_slots_used가 계속 1이면 예측 서버 쪽에 데이터 문제가 남아 있다는 신호라 모니터링이 필요하다.
+     */
+    private void logDataQuality(Restaurant restaurant, PredictionServerResponse body) {
+        PredictionServerResponse.DataQuality quality = body.getDataQuality();
+        if (quality == null) {
+            log.warn("예측 서버 응답에 data_quality가 없습니다: restaurant={}", restaurant);
+            return;
+        }
+
+        log.info("예측 데이터 품질: restaurant={}, observed_at={}, current_count_source={}, recent_slots_used={}/{}",
+                restaurant, body.getObservedAt(), quality.getCurrentCountSource(),
+                quality.getRecentSlotsUsed(), quality.getRecentSlotsExpected());
+
+        if (quality.getRecentSlotsUsed() != null && quality.getRecentSlotsUsed() <= 1) {
+            log.warn("예측에 사용된 최근 슬롯이 {}개뿐입니다. 지속되면 예측 서버 데이터 문제입니다: restaurant={}, observed_at={}",
+                    quality.getRecentSlotsUsed(), restaurant, body.getObservedAt());
+        }
+    }
+
+    private PredictionResponseDto toResponse(Restaurant restaurant, String requestedAt,
+                                             Connection observed, PredictionServerResponse prediction) {
+        List<PredictionResultDto> results = prediction.getResults() == null
+                ? Collections.emptyList()
+                : prediction.getResults().stream()
+                        .map(PredictionResultDto::from)
+                        .collect(Collectors.toList());
+
+        PredictionResponseDto.PredictionResponseDtoBuilder builder =
+                baseResponse(STATUS_OK, restaurant, requestedAt, observed)
+                        .observedAtSlot(prediction.getObservedAt())
+                        .results(results);
+
+        PredictionServerResponse.DataQuality quality = prediction.getDataQuality();
+        if (quality != null) {
+            builder.currentCountSource(quality.getCurrentCountSource())
+                    .recentSlotsExpected(quality.getRecentSlotsExpected())
+                    .recentSlotsUsed(quality.getRecentSlotsUsed());
+        }
+
+        return builder.build();
+    }
+
+    private PredictionResponseDto.PredictionResponseDtoBuilder baseResponse(String status, Restaurant restaurant,
+                                                                            String requestedAt, Connection observed) {
+        return PredictionResponseDto.builder()
+                .status(status)
+                .restaurantName(restaurant.name())
+                .requestedAt(requestedAt)
+                .observedAt(observed == null ? null : observed.getTime())
+                .observedValue(observed == null ? null : observed.getConnected());
+    }
+
+    private LocalDateTime parseTime(String time, LocalDateTime fallback) {
+        try {
+            return LocalDateTime.parse(time, FORMATTER);
+        } catch (DateTimeParseException e) {
+            log.warn("관측 시각 파싱 실패: time={}", time);
+            return fallback;
+        }
     }
 
     private PredictionResponseDto errorResponse(String status, String message,

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/connection/dto/PredictionResponseDto.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/connection/dto/PredictionResponseDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.Map;
+import java.util.List;
 
 @Getter
 @Setter
@@ -18,7 +18,22 @@ public class PredictionResponseDto {
     private String message;
     private String restaurantName;
     private String requestedAt;
+
+    /** 예측 요청에 사용한 관측 시각. 관측값이 없으면 null */
     private String observedAt;
+
+    /** 예측 요청에 사용한 관측 혼잡도. 모르면 null(0으로 폴백하지 않는다) */
     private Integer observedValue;
-    private Map<String, Object> predictions;
+
+    /** 예측 서버가 5분 격자로 반올림해 실제 사용한 시각 */
+    private String observedAtSlot;
+
+    /** 예측 서버가 current_count를 어디서 가져왔는지 (예: "observed") */
+    private String currentCountSource;
+
+    private Integer recentSlotsExpected;
+    private Integer recentSlotsUsed;
+
+    /** horizon별 예측 결과. 일부만 unavailable일 수 있다. */
+    private List<PredictionResultDto> results;
 }

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/connection/dto/PredictionResultDto.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/connection/dto/PredictionResultDto.java
@@ -1,0 +1,40 @@
+package com.SeeAndYouGo.SeeAndYouGo.connection.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * horizon 하나에 대한 예측 결과.
+ * horizon마다 개별 판정이므로 10/20분은 ok인데 60분만 unavailable인 응답이 정상적으로 나온다.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PredictionResultDto {
+    private Integer horizonMin;
+    private String targetTimestamp;
+
+    /** status가 "ok"가 아니면 null. 클라이언트는 0으로 폴백하지 말고 "예측 불가"로 표시해야 한다. */
+    private Double prediction;
+
+    /** "ok" | "unavailable" */
+    private String status;
+
+    /** status가 "unavailable"일 때만 존재 */
+    private String unavailableReason;
+
+    public static PredictionResultDto from(PredictionServerResponse.Result result) {
+        return PredictionResultDto.builder()
+                .horizonMin(result.getHorizonMin())
+                .targetTimestamp(result.getTargetTimestamp())
+                .prediction(result.isOk() ? result.getPrediction() : null)
+                .status(result.getStatus())
+                .unavailableReason(result.getUnavailableReason())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/connection/dto/PredictionServerRequest.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/connection/dto/PredictionServerRequest.java
@@ -1,0 +1,28 @@
+package com.SeeAndYouGo.SeeAndYouGo.connection.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 외부 예측 서버로 보내는 요청 바디.
+ *
+ * currentCount는 nullable이다. 현재 혼잡도를 모르는 경우 반드시 null을 보내야 하며,
+ * 0을 보내면 예측 서버가 "사람이 정말 0명"으로 해석해 예측값이 크게 낮아진다.
+ * horizons는 빈 배열일 수 없고 10/20/30/60만 허용된다.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PredictionServerRequest {
+    private final String restaurant;
+    private final String observedAt;
+    private final Double currentCount;
+    private final List<Integer> horizons;
+    private final boolean debug;
+}

--- a/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/connection/dto/PredictionServerResponse.java
+++ b/backend/src/main/java/com/SeeAndYouGo/SeeAndYouGo/connection/dto/PredictionServerResponse.java
@@ -1,0 +1,75 @@
+package com.SeeAndYouGo.SeeAndYouGo.connection.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * 외부 예측 서버의 응답 바디.
+ * 필드 추가는 하위 호환으로 계속 발생하므로 모르는 필드는 무시한다.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PredictionServerResponse {
+
+    public static final String RESULT_STATUS_OK = "ok";
+
+    /** 서버가 5분 격자로 반올림해 실제 사용한 시각 (11:32 → 11:30) */
+    private String observedAt;
+
+    /** 우리가 보낸 원본 시각 */
+    private String observedAtInput;
+
+    private String restaurant;
+
+    private DataQuality dataQuality;
+
+    private List<Result> results;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class DataQuality {
+        /** 예: "observed" - 예측 서버가 current_count를 어디서 가져왔는지 */
+        private String currentCountSource;
+        private Integer recentSlotsExpected;
+        /** 이 값이 지속적으로 1이면 예측 서버 쪽 데이터 문제 신호이므로 모니터링 대상이다. */
+        private Integer recentSlotsUsed;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Result {
+        private Integer horizonMin;
+        private String targetTimestamp;
+
+        /** status가 "ok"가 아니면 null이다. 0으로 폴백하면 안 된다. */
+        private Double prediction;
+
+        /** "ok" | "unavailable" */
+        private String status;
+
+        /**
+         * status가 "unavailable"일 때만 존재한다.
+         * no_baseline_for_target_slot / no_baseline_for_current_slot / no_coefficients_for_target_meal_period
+         */
+        private String unavailableReason;
+
+        public boolean isOk() {
+            return RESULT_STATUS_OK.equals(status);
+        }
+    }
+}

--- a/backend/src/test/java/com/SeeAndYouGo/SeeAndYouGo/connection/PredictionDtoTest.java
+++ b/backend/src/test/java/com/SeeAndYouGo/SeeAndYouGo/connection/PredictionDtoTest.java
@@ -1,0 +1,119 @@
+package com.SeeAndYouGo.SeeAndYouGo.connection;
+
+import com.SeeAndYouGo.SeeAndYouGo.connection.dto.PredictionResultDto;
+import com.SeeAndYouGo.SeeAndYouGo.connection.dto.PredictionServerRequest;
+import com.SeeAndYouGo.SeeAndYouGo.connection.dto.PredictionServerResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 테스트 목표: 예측 서버와 주고받는 JSON 계약을 고정한다.
+ *  - 요청은 snake_case이고 current_count는 모르면 null로 나간다(0으로 폴백하면 안 됨).
+ *  - 응답의 prediction은 null일 수 있고, status/unavailable_reason이 함께 온다.
+ *  - horizon마다 판정이 다르므로 일부만 unavailable인 응답도 파싱된다.
+ */
+@DisplayName("혼잡도 예측 서버 JSON 계약 - PredictionServerRequest/Response")
+class PredictionDtoTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("요청은 snake_case로 직렬화되고, 혼잡도를 모르면 current_count가 null로 나간다")
+    void serializeRequestWithNullCurrentCount() throws Exception {
+        PredictionServerRequest request = PredictionServerRequest.builder()
+                .restaurant("제1학생회관")
+                .observedAt("2026-05-11T11:32:41+09:00")
+                .currentCount(null)
+                .horizons(Arrays.asList(10, 20, 30, 60))
+                .debug(false)
+                .build();
+
+        String json = objectMapper.writeValueAsString(request);
+
+        assertThat(objectMapper.readTree(json).get("current_count").isNull()).isTrue();
+        assertThat(json).contains("\"observed_at\":\"2026-05-11T11:32:41+09:00\"");
+        assertThat(json).contains("\"horizons\":[10,20,30,60]");
+        assertThat(json).doesNotContain("currentCount");
+    }
+
+    @Test
+    @DisplayName("혼잡도를 알면 current_count가 숫자로 나간다")
+    void serializeRequestWithObservedCurrentCount() throws Exception {
+        PredictionServerRequest request = PredictionServerRequest.builder()
+                .restaurant("제1학생회관")
+                .observedAt("2026-05-11T11:32:41+09:00")
+                .currentCount(30.0)
+                .horizons(Arrays.asList(10, 60))
+                .debug(false)
+                .build();
+
+        assertThat(objectMapper.readTree(objectMapper.writeValueAsString(request))
+                .get("current_count").asDouble()).isEqualTo(30.0);
+    }
+
+    @Test
+    @DisplayName("horizon별로 ok와 unavailable이 섞인 응답을 파싱한다")
+    void deserializeMixedResults() throws Exception {
+        String body = "{"
+                + "\"restaurant\":\"제1학생회관\","
+                + "\"observed_at\":\"2026-05-11T11:30:00\","
+                + "\"observed_at_input\":\"2026-05-11T11:32:41\","
+                + "\"data_quality\":{\"current_count_source\":\"observed\","
+                + "\"recent_slots_expected\":5,\"recent_slots_used\":5},"
+                + "\"results\":["
+                + "{\"horizon_min\":10,\"target_timestamp\":\"2026-05-11T11:40:00\","
+                + "\"prediction\":84.2,\"status\":\"ok\"},"
+                + "{\"horizon_min\":60,\"target_timestamp\":\"2026-05-11T12:30:00\","
+                + "\"prediction\":null,\"status\":\"unavailable\","
+                + "\"unavailable_reason\":\"no_baseline_for_target_slot\"}"
+                + "]}";
+
+        PredictionServerResponse response = objectMapper.readValue(body, PredictionServerResponse.class);
+
+        assertThat(response.getObservedAt()).isEqualTo("2026-05-11T11:30:00");
+        assertThat(response.getObservedAtInput()).isEqualTo("2026-05-11T11:32:41");
+        assertThat(response.getDataQuality().getCurrentCountSource()).isEqualTo("observed");
+        assertThat(response.getDataQuality().getRecentSlotsUsed()).isEqualTo(5);
+
+        PredictionServerResponse.Result ok = response.getResults().get(0);
+        assertThat(ok.isOk()).isTrue();
+        assertThat(ok.getPrediction()).isEqualTo(84.2);
+
+        PredictionServerResponse.Result unavailable = response.getResults().get(1);
+        assertThat(unavailable.isOk()).isFalse();
+        assertThat(unavailable.getPrediction()).isNull();
+        assertThat(unavailable.getUnavailableReason()).isEqualTo("no_baseline_for_target_slot");
+    }
+
+    @Test
+    @DisplayName("모르는 필드가 추가돼도 파싱에 실패하지 않는다")
+    void ignoreUnknownFields() throws Exception {
+        String body = "{\"restaurant\":\"제1학생회관\",\"brand_new_field\":123,"
+                + "\"results\":[{\"horizon_min\":10,\"prediction\":1.0,\"status\":\"ok\",\"extra\":true}]}";
+
+        PredictionServerResponse response = objectMapper.readValue(body, PredictionServerResponse.class);
+
+        assertThat(response.getResults()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("unavailable 결과는 예측값 없이 사유만 담아 전달한다")
+    void mapUnavailableResultToDto() {
+        PredictionServerResponse.Result result = new PredictionServerResponse.Result();
+        result.setHorizonMin(60);
+        result.setStatus("unavailable");
+        result.setUnavailableReason("no_coefficients_for_target_meal_period");
+        result.setPrediction(12.3); // 서버가 값을 함께 보내더라도 무시해야 한다.
+
+        PredictionResultDto dto = PredictionResultDto.from(result);
+
+        assertThat(dto.getPrediction()).isNull();
+        assertThat(dto.getStatus()).isEqualTo("unavailable");
+        assertThat(dto.getUnavailableReason()).isEqualTo("no_coefficients_for_target_meal_period");
+    }
+}


### PR DESCRIPTION
## 배경

예측 서버 스펙이 바뀌었습니다. 핵심은 두 가지입니다.

- 요청의 `current_count`가 **nullable**이 됐습니다. 현재 혼잡도를 모를 때 `0`을 보내면 "사람이 정말 0명"으로 해석돼 예측이 40%가량 낮게 나옵니다.
- 응답의 `prediction`이 **null일 수 있습니다.** horizon마다 개별 판정이라 10/20분은 정상인데 60분만 null인 응답이 정상적으로 나옵니다.

나머지는 하위 호환(필드 추가만)입니다.

## 변경 사항

### 요청
- `PredictionServerRequest` 신규. `current_count`를 `Double` nullable로 전송합니다.
- 관측값이 없거나 `null`/음수(-1 비운영 센티널)면 **null을 보냅니다.** 0으로 폴백하는 경로는 없습니다.
- `horizons`를 부팅 시점에 10/20/30/60으로 필터링하고, 전부 걸러지면 기본값으로 폴백하며 `log.error`를 남깁니다. (허용 외 값 → 400, 빈 배열 → 422)

### 응답
- `PredictionServerResponse` 신규. `data_quality`와 `results[]`를 타입 파싱합니다. `@JsonIgnoreProperties(ignoreUnknown = true)`라 앞으로 필드가 더 추가돼도 파싱이 깨지지 않습니다.
- `PredictionResultDto` 신규. `status != "ok"`면 `prediction`을 강제로 null로 만듭니다. 서버가 값을 함께 보내더라도 무시합니다.
- `PredictionResponseDto`에서 `Map<String, Object> predictions`를 제거하고 `results` + `observedAtSlot` / `currentCountSource` / `recentSlotsExpected` / `recentSlotsUsed`를 추가했습니다.

### HTTP 상태 코드
| 코드 | 처리 |
|---|---|
| 200 (일부/전부 unavailable) | 정상 응답. `results[]`의 개별 `status`로 전달 |
| 404 | `UNSUPPORTED_RESTAURANT` (예측 미지원 식당) |
| 400 / 422 | `PREDICTION_FAILED` + 응답 바디 로깅 |

### 모니터링
`data_quality.recent_slots_used`를 `log.info`로 남기고, `<= 1`이면 별도 `log.warn`을 띄웁니다. 이 값이 계속 1이면 예측 서버 쪽 데이터 문제 신호입니다.

## 리뷰 포인트 — 판단해서 바꾼 것 2가지

**1. 관측값이 없을 때 동작이 바뀝니다.**
기존엔 ±5분 내 DB 관측값이 없으면 예측 서버를 호출조차 안 하고 `NO_OBSERVATION`을 반환했습니다. `current_count`가 nullable이 된 이유가 정확히 이 케이스라 판단해, 이제는 null로 보내 베이스라인 기반 예측을 받아옵니다. 기존 조기 반환을 유지하는 게 낫다면 되돌리겠습니다.

**2. `observed_at` 포맷을 바꿨습니다.**
`"2026-05-11 11:32:41"` → `"2026-05-11T11:32:41+09:00"`. 스펙상으로는 "그대로"지만 오프셋 포함이 권장이고, 예측 서버가 Render(UTC)에 떠 있어 naive 시각은 9시간 어긋날 여지가 있습니다. 스펙 예제 요청이 이 포맷이라 서버가 받는 것은 확실하지만, **머지 전에 한 번 실제로 찔러보는 것을 권합니다.**

## 테스트

`PredictionDtoTest` 5개 추가 — 요청 snake_case 직렬화, `current_count` null 전송, horizon별 ok/unavailable 혼재 응답 파싱, 미지의 필드 무시, unavailable → DTO 매핑. 전부 통과하고 기존 connection 테스트도 통과합니다.

## 배포 순서

**스프링이 먼저 나가야 합니다.** 예측 서버가 먼저 배포되면 `prediction: null`을 아직 못 받는 클라이언트가 파싱 에러를 내거나 null을 0으로 읽습니다.

다만 반대 구간에도 주의가 필요합니다. 이 PR이 먼저 배포되고 예측 서버가 아직 구버전이면 응답에 `status` 필드가 없어 `isOk()`가 false가 되고, **모든 horizon이 "예측 불가"로 보입니다.** 두 배포 사이의 간격을 짧게 가져가 주세요.

## 남은 작업 (이 PR 범위 밖)

체크리스트 3번(`status != "ok"`일 때 UI에 "예측 불가" 표시)은 프론트 작업입니다. 현재 `frontend/`와 `proposal_viewer/` 어디에서도 `/api/connection/prediction`을 호출하지 않아, `predictions` 맵을 `results`로 교체한 것이 깨뜨리는 소비자는 없습니다. `feat/congestion-prediction-viewer` 브랜치에 뷰어 작업이 있다면 그쪽은 확인이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
